### PR TITLE
feat: add --version argument to cli command

### DIFF
--- a/.github/workflows/build-linux-release.yml
+++ b/.github/workflows/build-linux-release.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Extract version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
+      - name: Write version.json
+        run: echo "{\"version\":\"${VERSION}\"}" > version.json
+
       - name: Build Docker image
         run: docker build -t work-reporter-builder .
 

--- a/.github/workflows/build-macos-release.yml
+++ b/.github/workflows/build-macos-release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
 
+      - name: Write version.json
+        run: echo "{\"version\":\"${VERSION}\"}" > version.json
+
       - name: Download and setup SPC
         run: |
           curl -L https://github.com/crazywhalecc/static-php-cli/releases/latest/download/spc-macos-aarch64.tar.gz -o spc.tar.gz

--- a/.github/workflows/build-phar-release.yml
+++ b/.github/workflows/build-phar-release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
 
+      - name: Write version.json
+        run: echo "{\"version\":\"${VERSION}\"}" > version.json
+
       - name: Build PHAR
         run: box compile
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 /.build/
 /dist/
+/version.json
 
 # llm
 /.claude/settings.local.json

--- a/bin/console
+++ b/bin/console
@@ -14,7 +14,16 @@ $workReportCommand = new WorkReportCommand(
         $configProvider,
 );
 
-$application = new Application();
+$version = 'dev';
+$versionFile = __DIR__ . '/../version.json';
+if (file_exists($versionFile)) {
+    $decoded = json_decode((string) file_get_contents($versionFile), true);
+    if (is_array($decoded) && isset($decoded['version']) && is_string($decoded['version']) && $decoded['version'] !== '') {
+        $version = $decoded['version'];
+    }
+}
+
+$application = new Application('work-reporter', $version);
 $application->addCommand($workReportCommand);
 $application->setDefaultCommand($workReportCommand->getName() ?? 'default', true);
 $application->run();

--- a/box.json
+++ b/box.json
@@ -15,7 +15,8 @@
   "files": [
     "bin/console",
     "composer.json",
-    "composer.lock"
+    "composer.lock",
+    "version.json"
   ],
   "main": "bin/console",
   "output": ".build/phar/work-reporter.phar"


### PR DESCRIPTION
Closes #5.

Adds the standard Symfony Console `--version` flag to the work-reporter CLI by passing a version string to the `Application` constructor. The version is sourced from a `version.json` file at the project root if present, otherwise falls back to `dev` so checked-out source builds still report something coherent.

```
$ bin/console --version
work-reporter dev

$ echo '{"version":"1.2.3"}' > version.json && bin/console --version
work-reporter 1.2.3
```

Files

- `bin/console` — read `version.json` (with `dev` fallback) and pass the resolved version to `new Application('work-reporter', $version)`.
- `box.json` — bundle `version.json` into the PHAR so the static binary inherits the value baked at CI time.
- `.gitignore` — `/version.json` is generated, not committed.
- `.github/workflows/build-{linux,macos,phar}-release.yml` — add a `Write version.json` step right after the existing `Extract version` step (Linux: before `docker build`; macOS: before `spc` builds; PHAR: before `box compile`). The same `${VERSION}` env var the workflows already extract gets serialised to `{"version":"<v>"}`.

Verification

- `make cs` — clean.
- `make stat-analyze` — clean.
- `make unit` — 166 tests pass.
- `bin/console --version` confirms both code paths above.