### PR TITLE
Friendly error message for missing config (#11)

### DIFF
--- a/src/Config/YamlConfigProvider.php
+++ b/src/Config/YamlConfigProvider.php
@@ -31,7 +31,12 @@ class YamlConfigProvider implements ConfigProvider
         $path = str_replace("~", (string)getenv("HOME"), $this->configPath);
 
         if (!file_exists($path)) {
-            throw new ConfigException(sprintf("Configuration file not found at: %s", $path));
+            throw new ConfigException(sprintf(
+                "Configuration file not found at: %s\n\n"
+                . "- You can generate a default configuration file by running: `work-reporter init`\n"
+                . "- Or specify a custom config path using the `-c flag: `work-reporter -c /path/to/config.yaml`",
+                $path,
+            ));
         }
 
         try {

--- a/src/Config/YamlConfigProvider.php
+++ b/src/Config/YamlConfigProvider.php
@@ -34,7 +34,7 @@ class YamlConfigProvider implements ConfigProvider
             throw new ConfigException(sprintf(
                 "Configuration file not found at: %s\n\n"
                 . "- You can generate a default configuration file by running: `work-reporter init`\n"
-                . "- Or specify a custom config path using the `-c flag: `work-reporter -c /path/to/config.yaml`",
+                . "- Or specify a custom config path using the `-c` flag: `work-reporter -c /path/to/config.yaml`",
                 $path,
             ));
         }

--- a/src/WorkReportCommand.php
+++ b/src/WorkReportCommand.php
@@ -3,6 +3,7 @@
 namespace Igancev\WorkReporter;
 
 use DateTimeImmutable;
+use Igancev\WorkReporter\Config\ConfigException;
 use Igancev\WorkReporter\Config\ConfigProvider;
 use Igancev\WorkReporter\Destination\Destination;
 use Igancev\WorkReporter\Destination\DestinationException;
@@ -98,8 +99,15 @@ class WorkReportCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $timeEntriesSource = $this->timeEntriesSourceFactory->build($this->configProvider->get()->source);
-        $this->destination = $this->destinationFactory->build($this->configProvider->get()->destination);
+        try {
+            $config = $this->configProvider->get();
+        } catch (ConfigException $e) {
+            $this->io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $timeEntriesSource = $this->timeEntriesSourceFactory->build($config->source);
+        $this->destination = $this->destinationFactory->build($config->destination);
 
         try {
             $timeEntries = $timeEntriesSource->fetchTimeEntries($this->from, $this->to);


### PR DESCRIPTION
Closes #11. Catches ConfigException in WorkReportCommand::execute() and displays a styled error with the expected config path and hints about init command and -c flag.