### PR TITLE
Add init command to generate default config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ work-reporter --version
 
 ---
 
+### 🔧 Quick Start
+
+Generate a default configuration file:
+
+```bash
+work-reporter init
+```
+
+This creates a config file at `~/.config/work-reporter/config.yaml` with a template you can edit.
+
+---
+
 ### ⚙️ Configuration
 
 Create a config file at `~/.config/work-reporter/config.yaml`:

--- a/bin/console
+++ b/bin/console
@@ -8,6 +8,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use Igancev\WorkReporter\Config\YamlConfigProvider;
 use Igancev\WorkReporter\Destination\ConcreteDestinationFactory;
 use Igancev\WorkReporter\Source\ConcreteSourceFactory;
+use Igancev\WorkReporter\InitCommand;
 use Igancev\WorkReporter\WorkReportCommand;
 use Symfony\Component\Console\Application;
 
@@ -31,5 +32,6 @@ if (file_exists($versionFile)) {
 
 $application = new Application('work-reporter', $version);
 $application->addCommand($workReportCommand);
-$application->setDefaultCommand($workReportCommand->getName() ?? 'default', true);
+$application->addCommand(new InitCommand());
+$application->setDefaultCommand($workReportCommand->getName() ?? 'default');
 $application->run();

--- a/src/InitCommand.php
+++ b/src/InitCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igancev\WorkReporter;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class InitCommand extends Command
+{
+    private const string DEFAULT_CONFIG_DIR = '~/.config/work-reporter';
+    private const string DEFAULT_CONFIG_PATH = '~/.config/work-reporter/config.yaml';
+
+    private const string DEFAULT_CONFIG_CONTENT = <<<YAML
+# Work Reporter configuration file
+# Documentation: https://github.com/igancev/work-reporter
+
+# Source type: superProductivity | plainJson
+source: plainJson
+
+# Destination type: youTrack
+destination: youTrack
+
+sources:
+  plainJson:
+    filePath: /path/to/time-entries.json
+  # superProductivity:
+  #   syncFilePath: /path/to/sync-file.json
+
+destinations:
+  youTrack:
+    url: https://youtrack.example.com
+    token: your-api-token
+YAML;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('init')
+            ->setDescription('Generate a default configuration file')
+            ->setHelp(
+                'Creates a default YAML configuration file at ' . self::DEFAULT_CONFIG_PATH . "\n"
+                . 'You can then edit it to match your setup.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $home = (string) getenv('HOME');
+        $configDir = str_replace('~', $home, self::DEFAULT_CONFIG_DIR);
+        $configPath = str_replace('~', $home, self::DEFAULT_CONFIG_PATH);
+
+        if (file_exists($configPath)) {
+            $io->warning(sprintf('Configuration file already exists at: %s', $configPath));
+            if (!$io->confirm('Do you want to overwrite it?', false)) {
+                $io->info('Aborted. Existing configuration was not modified.');
+                return Command::SUCCESS;
+            }
+        }
+
+        if (!is_dir($configDir)) {
+            if (!mkdir($configDir, 0755, true)) {
+                $io->error(sprintf('Failed to create directory: %s', $configDir));
+                return Command::FAILURE;
+            }
+        }
+
+        if (file_put_contents($configPath, self::DEFAULT_CONFIG_CONTENT) === false) {
+            $io->error(sprintf('Failed to write configuration file: %s', $configPath));
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Configuration file created at: %s', $configPath));
+        $io->info('Edit the file to configure your source and destination settings.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Igancev\WorkReporter\InitCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class InitCommandTest extends TestCase
+{
+    private string $tempDir;
+    private string $configDir;
+    private string $configPath;
+    private string|false $originalHome;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/work-reporter-test-' . uniqid();
+        $this->configDir = $this->tempDir . '/.config/work-reporter';
+        $this->configPath = $this->configDir . '/config.yaml';
+        $this->originalHome = getenv('HOME');
+
+        putenv('HOME=' . $this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->configPath)) {
+            unlink($this->configPath);
+        }
+        if (is_dir($this->configDir)) {
+            rmdir($this->configDir);
+        }
+        $parentDir = dirname($this->configDir);
+        if (is_dir($parentDir)) {
+            rmdir($parentDir);
+        }
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+
+        if ($this->originalHome !== false) {
+            putenv('HOME=' . $this->originalHome);
+        }
+    }
+
+    public function testCreatesConfigFileSuccessfully(): void
+    {
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+
+        $status = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertFileExists($this->configPath);
+        $this->assertStringContainsString('Configuration file created', $tester->getDisplay());
+
+        $content = (string) file_get_contents($this->configPath);
+        $this->assertStringContainsString('source:', $content);
+        $this->assertStringContainsString('destination:', $content);
+        $this->assertStringContainsString('youTrack', $content);
+    }
+
+    public function testCreatesDirectoryIfNotExists(): void
+    {
+        $this->assertDirectoryDoesNotExist($this->configDir);
+
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertDirectoryExists($this->configDir);
+        $this->assertFileExists($this->configPath);
+    }
+
+    public function testWarnsIfConfigAlreadyExists(): void
+    {
+        mkdir($this->configDir, 0755, true);
+        file_put_contents($this->configPath, 'existing content');
+
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+        $tester->setInputs(['no']);
+
+        $status = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertStringContainsString('already exists', $tester->getDisplay());
+        $this->assertSame('existing content', file_get_contents($this->configPath));
+    }
+
+    public function testOverwritesConfigWhenConfirmed(): void
+    {
+        mkdir($this->configDir, 0755, true);
+        file_put_contents($this->configPath, 'old content');
+
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+        $tester->setInputs(['yes']);
+
+        $status = $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $status);
+        $this->assertNotSame('old content', file_get_contents($this->configPath));
+        $this->assertStringContainsString('source:', (string) file_get_contents($this->configPath));
+    }
+}


### PR DESCRIPTION
Add `init` command that generates a default YAML config at `~/.config/work-reporter/config.yaml` with overwrite protection and confirmation prompt.

Also updates `bin/console` to support multi-command mode, adds unit tests, and documents the command in README.

Closes #6
