### PR TITLE
refactor: extract version reading into Version class

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,9 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use Igancev\WorkReporter\Config\YamlConfigProvider;
 use Igancev\WorkReporter\Destination\ConcreteDestinationFactory;
-use Igancev\WorkReporter\Source\ConcreteSourceFactory;
 use Igancev\WorkReporter\InitCommand;
+use Igancev\WorkReporter\Source\ConcreteSourceFactory;
+use Igancev\WorkReporter\Version;
 use Igancev\WorkReporter\WorkReportCommand;
 use Symfony\Component\Console\Application;
 
@@ -21,16 +22,10 @@ $workReportCommand = new WorkReportCommand(
 $binaryPath = $_SERVER['PHP_SELF'] ?? 'work-reporter';
 $workReportCommand->setName($binaryPath);
 
-$version = 'dev';
-$versionFile = __DIR__ . '/../version.json';
-if (file_exists($versionFile)) {
-    $decoded = json_decode((string) file_get_contents($versionFile), true);
-    if (is_array($decoded) && isset($decoded['version']) && is_string($decoded['version']) && $decoded['version'] !== '') {
-        $version = $decoded['version'];
-    }
-}
-
-$application = new Application('work-reporter', $version);
+$application = new Application(
+    'work-reporter',
+    Version::fromFile(__DIR__ . '/../version.json'),
+);
 $application->addCommand($workReportCommand);
 $application->addCommand(new InitCommand());
 $application->setDefaultCommand($workReportCommand->getName() ?? 'default');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 8
     paths:
+        - bin
         - src
         - tests

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igancev\WorkReporter;
+
+final class Version
+{
+    public const DEFAULT = 'dev';
+
+    public static function fromFile(string $path): string
+    {
+        if (!file_exists($path)) {
+            return self::DEFAULT;
+        }
+
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            return self::DEFAULT;
+        }
+
+        $decoded = json_decode($contents, true);
+        if (!is_array($decoded)) {
+            return self::DEFAULT;
+        }
+
+        $version = $decoded['version'] ?? null;
+        if (!is_string($version) || $version === '') {
+            return self::DEFAULT;
+        }
+
+        return $version;
+    }
+}

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Igancev\WorkReporter\Version;
+use PHPUnit\Framework\TestCase;
+
+final class VersionTest extends TestCase
+{
+    private string $tmpFile;
+
+    protected function setUp(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'wr-version-');
+        if ($tmp === false) {
+            self::fail('Could not create temporary file.');
+        }
+        $this->tmpFile = $tmp;
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tmpFile)) {
+            unlink($this->tmpFile);
+        }
+    }
+
+    public function testReturnsDefaultWhenFileMissing(): void
+    {
+        unlink($this->tmpFile);
+        self::assertSame('dev', Version::fromFile($this->tmpFile));
+    }
+
+    public function testReturnsDefaultWhenJsonIsMalformed(): void
+    {
+        file_put_contents($this->tmpFile, '{not json');
+        self::assertSame('dev', Version::fromFile($this->tmpFile));
+    }
+
+    public function testReturnsDefaultWhenVersionKeyMissingOrEmpty(): void
+    {
+        file_put_contents($this->tmpFile, (string) json_encode(['version' => '']));
+        self::assertSame('dev', Version::fromFile($this->tmpFile));
+
+        file_put_contents($this->tmpFile, (string) json_encode(['other' => '1.0.0']));
+        self::assertSame('dev', Version::fromFile($this->tmpFile));
+    }
+
+    public function testReturnsVersionStringWhenPresent(): void
+    {
+        file_put_contents($this->tmpFile, (string) json_encode(['version' => '1.2.3']));
+        self::assertSame('1.2.3', Version::fromFile($this->tmpFile));
+    }
+}


### PR DESCRIPTION
Closes #17.

## Summary

Extracts the `version.json` parsing/validation out of `bin/console` into a small
`Igancev\WorkReporter\Version` class with `fromFile(string $path): string`. Adds
unit tests for the four cases listed in the issue and adds `bin/` to PHPStan's
scanned paths so the bootstrap script gets analyzed too.

## Changes

- `src/Version.php` (new): `Version::fromFile()` returns the version string
  from `version.json`, falling back to `'dev'` (a public `Version::DEFAULT`
  constant) on missing file, unreadable file, malformed JSON, or missing /
  empty `version` key.
- `tests/VersionTest.php` (new): four test cases covering the acceptance
  criteria - missing file, malformed JSON, missing-or-empty version key, and a
  valid version string.
- `bin/console`: replaces the inline `$version = 'dev'` block plus
  `file_exists` / `json_decode` / type validation with a single
  `Version::fromFile(__DIR__ . '/../version.json')` call. Bootstrap is back to
  one statement per command.
- `phpstan.neon`: adds `bin` to `paths` so `bin/console` participates in the
  level-8 analysis. `phpcs.xml.dist` already lists `<file>bin</file>`, so this
  closes the asymmetry the issue called out.

## Verification

- `vendor/bin/phpunit tests/VersionTest.php` -> OK (4 tests, 5 assertions).
- `vendor/bin/phpstan analyse src/Version.php tests/VersionTest.php
  --memory-limit=512M` -> No errors.
- The existing local checkout failed `composer cs` and the full
  `composer unit` for reasons unrelated to this change (Slevomat coding
  standard / Laravel\Prompts dependencies). Both `composer cs` and the full
  `unit` suite fail the same way on `main` without my changes, so I have not
  treated them as regressions. CI should have those deps installed; happy to
  amend if anything specific to `Version` flags up.

## Notes

- `Version::DEFAULT = 'dev'` is exposed as a public constant so callers and
  tests can share the same fallback string instead of duplicating the literal.
- Kept the rest of `bin/console` (init command wiring, `setName`, etc.) intact;
  only the version block changed.
