### PR TITLE
Refactor Version class and improve test coverage

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -6,7 +6,7 @@ namespace Igancev\WorkReporter;
 
 final class Version
 {
-    public const DEFAULT = 'dev';
+    private const string DEFAULT = 'dev';
 
     public static function fromFile(string $path): string
     {
@@ -14,7 +14,7 @@ final class Version
             return self::DEFAULT;
         }
 
-        $contents = file_get_contents($path);
+        $contents = @file_get_contents($path);
         if ($contents === false) {
             return self::DEFAULT;
         }

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests;
 
 use Igancev\WorkReporter\Version;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Version::class)]
 final class VersionTest extends TestCase
 {
     private string $tmpFile;
@@ -52,5 +54,16 @@ final class VersionTest extends TestCase
     {
         file_put_contents($this->tmpFile, (string) json_encode(['version' => '1.2.3']));
         self::assertSame('1.2.3', Version::fromFile($this->tmpFile));
+    }
+
+    public function testReturnsDefaultWhenFileCannotBeRead(): void
+    {
+        chmod($this->tmpFile, 0000);
+
+        try {
+            self::assertSame('dev', Version::fromFile($this->tmpFile));
+        } finally {
+            chmod($this->tmpFile, 0644);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Made `Version::DEFAULT` constant private and typed as `string` for better encapsulation and type safety.
- Added error suppression (`@`) to `file_get_contents` in `Version::fromFile` to handle unreadable files gracefully.
- Improved `VersionTest` with `#[CoversClass]` attribute.
- Added a new test case `testReturnsDefaultWhenFileCannotBeRead` to verify behavior when the version file exists but cannot be read.

## Test plan
- Run `make check-all` to verify coding standards, static analysis, and all tests pass.
- Manually verified the specific test case: `vendor/bin/phpunit tests/VersionTest.php`.