### PR TITLE
test: add edge-case tests for InitCommand

### DIFF
--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tests;
 
 use Igancev\WorkReporter\InitCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
+#[CoversClass(InitCommand::class)]
 class InitCommandTest extends TestCase
 {
     private string $tempDir;
@@ -107,5 +109,50 @@ class InitCommandTest extends TestCase
         $this->assertSame(Command::SUCCESS, $status);
         $this->assertNotSame('old content', file_get_contents($this->configPath));
         $this->assertStringContainsString('source:', (string) file_get_contents($this->configPath));
+    }
+
+    public function testFailsIfDirectoryCannotBeCreated(): void
+    {
+        // Create a file with the same name as the intended config directory
+        // This makes mkdir() fail
+        $parentDir = dirname($this->configDir);
+        if (!is_dir($parentDir)) {
+            mkdir($parentDir, 0755, true);
+        }
+        file_put_contents($this->configDir, 'I am a file, not a directory');
+
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+
+        // Expect FAILURE status
+        $status = @$tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('Failed to create directory', $tester->getDisplay());
+
+        // Cleanup
+        unlink($this->configDir);
+    }
+
+    public function testFailsIfFileCannotBeWritten(): void
+    {
+        // Create the directory but make it read-only
+        if (!is_dir($this->configDir)) {
+            mkdir($this->configDir, 0755, true);
+        }
+        chmod($this->configDir, 0555);
+
+        $command = new InitCommand();
+        $tester = new CommandTester($command);
+
+        // Expect FAILURE status
+        // Use @ to suppress the warning from file_put_contents
+        $status = @$tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $status);
+        $this->assertStringContainsString('Failed to write configuration file', $tester->getDisplay());
+
+        // Restore permissions for cleanup
+        chmod($this->configDir, 0755);
     }
 }


### PR DESCRIPTION
Added unit tests to cover error handling in InitCommand. Also added CoversClass attribute.