### PR TITLE
refactor: reorganize test structure to separate unit and functional tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "cs": "vendor/bin/phpcs -p",
         "cs-fix": "vendor/bin/phpcbf",
         "stat-analyze": "vendor/bin/phpstan analyse --memory-limit=512M",
-        "unit": "vendor/bin/phpunit",
-        "functional": "vendor/bin/phpunit --group functional"
+        "unit": "vendor/bin/phpunit --testsuite=unit",
+        "functional": "vendor/bin/phpunit --testsuite=functional"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,19 +6,12 @@
          cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="unit">
-            <directory>tests</directory>
-            <exclude>tests/Functional</exclude>
+            <directory>tests/Unit</directory>
         </testsuite>
         <testsuite name="functional">
             <directory>tests/Functional</directory>
         </testsuite>
     </testsuites>
-
-    <groups>
-        <exclude>
-            <group>functional</group>
-        </exclude>
-    </groups>
 
     <source>
         <include>

--- a/tests/Functional/Readme.md
+++ b/tests/Functional/Readme.md
@@ -1,0 +1,25 @@
+# Functional Tests
+
+Functional tests in this project use **[Testcontainers](https://testcontainers.com/)** to ensure reliability and environment parity.
+
+## What is Testcontainers?
+
+Testcontainers is a library that allows you to spin up real instances of databases, message brokers, or any other service in Docker containers during test execution. 
+
+Instead of mocking external dependencies or relying on a manually pre-configured environment, the project automatically:
+1. Starts the required Docker containers (e.g., YouTrack).
+2. Runs tests against these live instances.
+3. Cleans up (stops and removes) the containers after tests complete.
+
+## How to Work with Them
+
+- **Requirements**: You must have a Docker-compatible container runtime installed and running (Docker Desktop, Colima, etc.).
+- **Execution**: Functional tests are usually part of the full test suite or can be run specifically via PHPUnit:
+  ```bash
+  vendor/bin/phpunit tests/Functional
+  ```
+
+## Further Reading
+
+- [Official Testcontainers Documentation](https://testcontainers.com/getting-started/)
+- [Testcontainers for PHP](https://github.com/testcontainers/testcontainers-php)

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Config;
+namespace Tests\Unit\Config;
 
 use Igancev\WorkReporter\Config\Config;
 use Igancev\WorkReporter\Config\DestinationConfig\DestinationsConfig;

--- a/tests/Unit/Config/YamlConfigProviderTest.php
+++ b/tests/Unit/Config/YamlConfigProviderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Config;
+namespace Tests\Unit\Config;
 
 use Igancev\WorkReporter\Config\ConfigException;
 use Igancev\WorkReporter\Config\YamlConfigProvider;

--- a/tests/Unit/Destination/ConcreteDestinationFactoryTest.php
+++ b/tests/Unit/Destination/ConcreteDestinationFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination;
+namespace Tests\Unit\Destination;
 
 use Igancev\WorkReporter\Config\Config;
 use Igancev\WorkReporter\Config\ConfigProvider;

--- a/tests/Unit/Destination/YouTrack/ProjectCollectionTest.php
+++ b/tests/Unit/Destination/YouTrack/ProjectCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination\YouTrack;
+namespace Tests\Unit\Destination\YouTrack;
 
 use Igancev\WorkReporter\Destination\YouTrack\Project;
 use Igancev\WorkReporter\Destination\YouTrack\ProjectCollection;

--- a/tests/Unit/Destination/YouTrack/TaskIdCollectionTest.php
+++ b/tests/Unit/Destination/YouTrack/TaskIdCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination\YouTrack;
+namespace Tests\Unit\Destination\YouTrack;
 
 use Igancev\WorkReporter\Destination\YouTrack\TaskId;
 use Igancev\WorkReporter\Destination\YouTrack\TaskIdCollection;

--- a/tests/Unit/Destination/YouTrack/TaskIdTest.php
+++ b/tests/Unit/Destination/YouTrack/TaskIdTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination\YouTrack;
+namespace Tests\Unit\Destination\YouTrack;
 
 use Igancev\WorkReporter\Destination\YouTrack\TaskId;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Destination/YouTrack/WorkItemTypeCollectionTest.php
+++ b/tests/Unit/Destination/YouTrack/WorkItemTypeCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination\YouTrack;
+namespace Tests\Unit\Destination\YouTrack;
 
 use Igancev\WorkReporter\Destination\YouTrack\Project;
 use Igancev\WorkReporter\Destination\YouTrack\WorkItemType;

--- a/tests/Unit/Destination/YouTrack/YouTrackDestinationTest.php
+++ b/tests/Unit/Destination/YouTrack/YouTrackDestinationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Destination\YouTrack;
+namespace Tests\Unit\Destination\YouTrack;
 
 use Amp\ByteStream\BufferException;
 use Amp\ByteStream\ReadableStream;

--- a/tests/Unit/DurationTest.php
+++ b/tests/Unit/DurationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use Igancev\WorkReporter\Duration;
 use Igancev\WorkReporter\InvalidDurationException;

--- a/tests/Unit/InitCommandTest.php
+++ b/tests/Unit/InitCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use Igancev\WorkReporter\InitCommand;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Source/ConcreteSourceFactoryTest.php
+++ b/tests/Unit/Source/ConcreteSourceFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source;
+namespace Tests\Unit\Source;
 
 use Igancev\WorkReporter\Config\Config;
 use Igancev\WorkReporter\Config\ConfigProvider;

--- a/tests/Unit/Source/PlainJson/PlainJsonTimeEntriesSourceTest.php
+++ b/tests/Unit/Source/PlainJson/PlainJsonTimeEntriesSourceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\PlainJson;
+namespace Tests\Unit\Source\PlainJson;
 
 use DateTimeImmutable;
 use Igancev\WorkReporter\Duration;
@@ -19,7 +19,7 @@ class PlainJsonTimeEntriesSourceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->jsonFilePath = __DIR__ . '/../../../tests/data/jsonList/jsonList.json';
+        $this->jsonFilePath = __DIR__ . '/../../../data/jsonList/jsonList.json';
     }
 
     public function testFetchTimeEntriesSuccessfully(): void

--- a/tests/Unit/Source/SuperProductivity/StorageTest.php
+++ b/tests/Unit/Source/SuperProductivity/StorageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\SuperProductivity;
+namespace Tests\Unit\Source\SuperProductivity;
 
 use Igancev\WorkReporter\Source\SuperProductivity\Storage;
 use Igancev\WorkReporter\Source\SuperProductivity\Tag;

--- a/tests/Unit/Source/SuperProductivity/SuperProductivitySyncDataSourceTest.php
+++ b/tests/Unit/Source/SuperProductivity/SuperProductivitySyncDataSourceTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\SuperProductivity;
+namespace Tests\Unit\Source\SuperProductivity;
 
-use Igancev\WorkReporter\TimeEntry;
 use DateTimeImmutable;
 use Igancev\WorkReporter\Duration;
 use Igancev\WorkReporter\Source\SuperProductivity\SuperProductivitySyncSource;
+use Igancev\WorkReporter\TimeEntry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +18,7 @@ class SuperProductivitySyncDataSourceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->metaFilePath = __DIR__ . '/../../data/superproductivity/__meta_';
+        $this->metaFilePath = __DIR__ . '/../../../data/superproductivity/__meta_';
     }
 
     public function testGetTimeEntries(): void

--- a/tests/Unit/Source/SuperProductivity/TagTest.php
+++ b/tests/Unit/Source/SuperProductivity/TagTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\SuperProductivity;
+namespace Tests\Unit\Source\SuperProductivity;
 
 use Igancev\WorkReporter\Source\SuperProductivity\Tag;
 use InvalidArgumentException;

--- a/tests/Unit/Source/SuperProductivity/TaskFactoryTest.php
+++ b/tests/Unit/Source/SuperProductivity/TaskFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\SuperProductivity;
+namespace Tests\Unit\Source\SuperProductivity;
 
 use Igancev\WorkReporter\Source\SuperProductivity\Storage;
 use Igancev\WorkReporter\Source\SuperProductivity\Tag;

--- a/tests/Unit/Source/SuperProductivity/TaskTest.php
+++ b/tests/Unit/Source/SuperProductivity/TaskTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Source\SuperProductivity;
+namespace Tests\Unit\Source\SuperProductivity;
 
 use Igancev\WorkReporter\Duration;
 use Igancev\WorkReporter\Source\SuperProductivity\Tag;

--- a/tests/Unit/TimeEntryCollectionTest.php
+++ b/tests/Unit/TimeEntryCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use DateTimeImmutable;
 use Igancev\WorkReporter\Duration;

--- a/tests/Unit/TimeEntryTest.php
+++ b/tests/Unit/TimeEntryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use DateTimeImmutable;
 use Igancev\WorkReporter\Duration;

--- a/tests/Unit/VersionTest.php
+++ b/tests/Unit/VersionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use Igancev\WorkReporter\Version;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/WorkReportCommandTest.php
+++ b/tests/Unit/WorkReportCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests;
+namespace Tests\Unit;
 
 use ArrayIterator;
 use DateTimeImmutable;


### PR DESCRIPTION
Reorganized the test suite by moving unit tests into a dedicated directory and updating the configuration.

Summary of changes:
- Moved all unit tests to `tests/Unit/` mirroring the `src/` structure.
- Updated namespaces in all moved test files.
- Simplified `phpunit.xml` by using directory-based test suites (`unit` and `functional`).
- Updated `composer.json` scripts `unit` and `functional` to use `--testsuite`.
- Adjusted relative paths to test data in unit tests.
- Added `tests/Functional/Readme.md` describing how to run functional tests.

These changes make the test structure more predictable and easier to manage as the project grows.

Closes #56