### PR TITLE
Add application ASCII banner

### DIFF
--- a/src/Banner.php
+++ b/src/Banner.php
@@ -51,7 +51,6 @@ final class Banner
             $output->writeln($line . "\033[0m");
         }
 
-        $output->writeln('');
     }
 
     /**

--- a/src/Banner.php
+++ b/src/Banner.php
@@ -50,7 +50,6 @@ final class Banner
 
             $output->writeln($line . "\033[0m");
         }
-
     }
 
     /**

--- a/src/Banner.php
+++ b/src/Banner.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igancev\WorkReporter;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class Banner
+{
+    private const array WORK_LINES = [
+        '█   █ █▀█ █▀▄ █▄▀',
+        '█ █ █ █ █ █▄▀ ██ ',
+        '▀▀ ▀▀ ▀▀▀ ▀ ▀ ▀ ▀',
+    ];
+
+    private const array SEPARATOR_LINES = [
+        '    ',
+        ' ▄▄ ',
+        '    ',
+    ];
+
+    private const array REPORTER_LINES = [
+        '█▀▄ █▀▀ █▀▄ █▀█ █▀▄ ▀█▀ █▀▀ █▀▄',
+        '█▄▀ █▀  █▄▀ █ █ █▄▀  █  █▀  █▄▀',
+        '▀ ▀ ▀▀▀ ▀   ▀▀▀ ▀ ▀  ▀  ▀▀▀ ▀ ▀',
+    ];
+
+    private const array WORK_START_RGB = [31, 85, 195];
+    private const array WORK_END_RGB = [104, 159, 241];
+    private const array REPORTER_START_RGB = [251, 67, 251];
+    private const array REPORTER_END_RGB = [251, 64, 109];
+
+    public static function render(OutputInterface $output): void
+    {
+        $output->writeln('');
+
+        for ($row = 0; $row < count(self::WORK_LINES); $row++) {
+            $line = self::colorize(
+                self::WORK_LINES[$row],
+                self::WORK_START_RGB,
+                self::WORK_END_RGB,
+            );
+            $line .= "\033[0m" . self::SEPARATOR_LINES[$row];
+            $line .= self::colorize(
+                self::REPORTER_LINES[$row],
+                self::REPORTER_START_RGB,
+                self::REPORTER_END_RGB,
+            );
+
+            $output->writeln($line . "\033[0m");
+        }
+
+        $output->writeln('');
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function plain(): array
+    {
+        $lines = [];
+        for ($row = 0; $row < count(self::WORK_LINES); $row++) {
+            $lines[] = self::WORK_LINES[$row]
+                . self::SEPARATOR_LINES[$row]
+                . self::REPORTER_LINES[$row];
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param int[] $startRgb
+     * @param int[] $endRgb
+     */
+    private static function colorize(string $text, array $startRgb, array $endRgb): string
+    {
+        $chars = mb_str_split($text);
+        $maxCol = mb_strlen($text) - 1;
+        $result = '';
+
+        foreach ($chars as $col => $char) {
+            if ($char === ' ') {
+                $result .= $char;
+                continue;
+            }
+
+            $t = $maxCol > 0 ? $col / $maxCol : 0.0;
+            $r = (int) round($startRgb[0] + ($endRgb[0] - $startRgb[0]) * $t);
+            $g = (int) round($startRgb[1] + ($endRgb[1] - $startRgb[1]) * $t);
+            $b = (int) round($startRgb[2] + ($endRgb[2] - $startRgb[2]) * $t);
+
+            $result .= "\033[38;2;{$r};{$g};{$b}m{$char}";
+        }
+
+        return $result;
+    }
+}

--- a/src/Banner.php
+++ b/src/Banner.php
@@ -30,8 +30,9 @@ final class Banner
     private const array WORK_END_RGB = [104, 159, 241];
     private const array REPORTER_START_RGB = [251, 67, 251];
     private const array REPORTER_END_RGB = [251, 64, 109];
+    private const string REPO_URL = 'github.com/igancev/work-reporter';
 
-    public static function render(OutputInterface $output): void
+    public static function render(OutputInterface $output, string $version = 'dev'): void
     {
         $output->writeln('');
 
@@ -50,6 +51,8 @@ final class Banner
 
             $output->writeln($line . "\033[0m");
         }
+
+        self::renderTagline($output, $version);
     }
 
     /**
@@ -65,6 +68,35 @@ final class Banner
         }
 
         return $lines;
+    }
+
+    private static function renderTagline(OutputInterface $output, string $version): void
+    {
+        $bannerWidth = mb_strlen(self::WORK_LINES[0] . self::SEPARATOR_LINES[0] . self::REPORTER_LINES[0]);
+        $repoUrl = 'https://' . self::REPO_URL;
+        $ghLink = self::terminalLink('GitHub', $repoUrl);
+        $starLink = self::terminalLink('⭐ Please star us if you find it useful!', $repoUrl);
+
+        $lines = [
+            sprintf("\033[33mv%s\033[0m · Made with \033[91m❤\033[0m · %s", $version, $ghLink),
+            $starLink,
+        ];
+
+        foreach ($lines as $line) {
+            $visualWidth = mb_strlen(self::stripAnsi($line));
+            $pad = max(0, (int) floor(($bannerWidth - $visualWidth) / 2));
+            $output->writeln(str_repeat(' ', $pad) . $line);
+        }
+    }
+
+    private static function terminalLink(string $text, string $url): string
+    {
+        return "\033]8;;{$url}\033\\{$text}\033]8;;\033\\";
+    }
+
+    private static function stripAnsi(string $text): string
+    {
+        return (string) preg_replace('/\033(?:\[[0-9;]*m|\]8;;[^\033]*\033\\\\)/', '', $text);
     }
 
     /**

--- a/src/WorkReportCommand.php
+++ b/src/WorkReportCommand.php
@@ -117,7 +117,7 @@ class WorkReportCommand extends Command
             return Command::FAILURE;
         }
 
-        Banner::render($output);
+        Banner::render($output, $this->getApplication()?->getVersion() ?? 'dev');
 
         try {
             $config = $this->configProvider->get();

--- a/src/WorkReportCommand.php
+++ b/src/WorkReportCommand.php
@@ -24,7 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\title;
 
 #[AsCommand(
     name: 'work:report',
@@ -118,7 +117,7 @@ class WorkReportCommand extends Command
             return Command::FAILURE;
         }
 
-        title('Work Reporter');
+        Banner::render($output);
 
         try {
             $config = $this->configProvider->get();

--- a/tests/Unit/BannerTest.php
+++ b/tests/Unit/BannerTest.php
@@ -108,4 +108,53 @@ final class BannerTest extends TestCase
         $this->assertTrue($hasBlue, 'Expected blue gradient colors for WORK');
         $this->assertTrue($hasPink, 'Expected pink gradient colors for REPORTER');
     }
+
+    public function testPlainReturnsExactBannerContent(): void
+    {
+        // Act
+        $lines = Banner::plain();
+
+        // Assert
+        $this->assertCount(3, $lines);
+        $this->assertSame(
+            '█   █ █▀█ █▀▄ █▄▀    █▀▄ █▀▀ █▀▄ █▀█ █▀▄ ▀█▀ █▀▀ █▀▄',
+            $lines[0],
+        );
+        $this->assertSame(
+            '█ █ █ █ █ █▄▀ ██  ▄▄ █▄▀ █▀  █▄▀ █ █ █▄▀  █  █▀  █▄▀',
+            $lines[1],
+        );
+        $this->assertSame(
+            '▀▀ ▀▀ ▀▀▀ ▀ ▀ ▀ ▀    ▀ ▀ ▀▀▀ ▀   ▀▀▀ ▀ ▀  ▀  ▀▀▀ ▀ ▀',
+            $lines[2],
+        );
+    }
+
+    public function testRenderOutputMatchesPlainTextStructure(): void
+    {
+        // Arrange
+        $output = new BufferedOutput();
+
+        // Act
+        Banner::render($output);
+
+        // Assert
+        $content = $output->fetch();
+        $outputLines = explode("\n", $content);
+
+        // First line should be empty (the leading writeln(''))
+        $this->assertSame('', $outputLines[0], 'Render output should start with an empty line');
+
+        // Strip ANSI codes from banner lines and compare with plain() text
+        $plainLines = Banner::plain();
+        $strippedBannerLines = [];
+        for ($i = 1; $i <= count($plainLines); $i++) {
+            $stripped = preg_replace('/\033(?:\[[0-9;]*m|\]8;;[^\033]*\033\\\\)/', '', $outputLines[$i]);
+            $strippedBannerLines[] = $stripped;
+        }
+
+        foreach ($plainLines as $idx => $expected) {
+            $this->assertSame($expected, $strippedBannerLines[$idx]);
+        }
+    }
 }

--- a/tests/Unit/BannerTest.php
+++ b/tests/Unit/BannerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Igancev\WorkReporter\Banner;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(Banner::class)]
+final class BannerTest extends TestCase
+{
+    public function testPlainReturnsNonEmptyArray(): void
+    {
+        // Act
+        $lines = Banner::plain();
+
+        // Assert
+        $this->assertNotEmpty($lines);
+    }
+
+    public function testPlainLinesHaveConsistentWidth(): void
+    {
+        // Act
+        $lines = Banner::plain();
+        $widths = array_map(mb_strlen(...), $lines);
+
+        // Assert
+        $this->assertSame(1, count(array_unique($widths)));
+    }
+
+    public function testRenderWritesToOutput(): void
+    {
+        // Arrange
+        $output = new BufferedOutput();
+
+        // Act
+        Banner::render($output);
+
+        // Assert
+        $content = $output->fetch();
+        $this->assertNotEmpty($content);
+        $this->assertMatchesRegularExpression('/\x1b\[38;2;\d+;\d+;\d+m/', $content);
+        $this->assertStringContainsString("\033[0m", $content);
+    }
+
+    public function testRenderOutputContainsBlockCharacters(): void
+    {
+        // Arrange
+        $output = new BufferedOutput();
+
+        // Act
+        Banner::render($output);
+
+        // Assert
+        $content = $output->fetch();
+        $this->assertMatchesRegularExpression('/[█▀▄]/', $content);
+    }
+
+    public function testRenderContainsBothGradients(): void
+    {
+        // Arrange
+        $output = new BufferedOutput();
+
+        // Act
+        Banner::render($output);
+
+        // Assert
+        $content = $output->fetch();
+        preg_match_all('/\x1b\[38;2;(\d+);(\d+);(\d+)m/', $content, $matches, PREG_SET_ORDER);
+        $this->assertNotEmpty($matches);
+
+        $hasBlue = false;
+        $hasPink = false;
+
+        foreach ($matches as $match) {
+            $r = (int) $match[1];
+            $b = (int) $match[3];
+
+            if ($r < 150 && $b > 150) {
+                $hasBlue = true;
+            }
+
+            if ($r > 200 && $b > 100) {
+                $hasPink = true;
+            }
+        }
+
+        $this->assertTrue($hasBlue, 'Expected blue gradient colors for WORK');
+        $this->assertTrue($hasPink, 'Expected pink gradient colors for REPORTER');
+    }
+}

--- a/tests/Unit/BannerTest.php
+++ b/tests/Unit/BannerTest.php
@@ -59,6 +59,23 @@ final class BannerTest extends TestCase
         $this->assertMatchesRegularExpression('/[█▀▄]/', $content);
     }
 
+    public function testRenderOutputContainsTagline(): void
+    {
+        // Arrange
+        $output = new BufferedOutput();
+
+        // Act
+        Banner::render($output, '1.2.3');
+
+        // Assert
+        $content = $output->fetch();
+        $this->assertStringContainsString('v1.2.3', $content);
+        $this->assertStringContainsString('GitHub', $content);
+        $this->assertStringContainsString('https://github.com/igancev/work-reporter', $content);
+        $this->assertStringContainsString('❤', $content);
+        $this->assertStringContainsString('Please star us if you find it useful', $content);
+    }
+
     public function testRenderContainsBothGradients(): void
     {
         // Arrange

--- a/tests/Unit/DurationTest.php
+++ b/tests/Unit/DurationTest.php
@@ -113,6 +113,7 @@ final class DurationTest extends TestCase
             'one minute' => [60000, 1],
             'one hour' => [3600000, 60],
             'large value' => [600_000_000, 10000],
+            'value where /60000 and /59999 diverge' => [1_800_000_000, 30_000],
         ];
     }
 
@@ -142,6 +143,14 @@ final class DurationTest extends TestCase
             'zero hours' => ['0h', 0],
             'case insensitive' => ['1H 15M', 75 * 60000],
             'with extra spaces' => ['  2h   5m  ', 125 * 60000],
+            'numeric boundary (max safe minutes)' => [
+                (string) intdiv(PHP_INT_MAX, 60000),
+                intdiv(PHP_INT_MAX, 60000) * 60000,
+            ],
+            'unit boundary (max safe minutes)' => [
+                intdiv(PHP_INT_MAX, 60000) . 'm',
+                intdiv(PHP_INT_MAX, 60000) * 60000,
+            ],
         ];
     }
 
@@ -177,6 +186,21 @@ final class DurationTest extends TestCase
         ];
     }
 
+    public function testFromEmptyStringThrowsWithSpecificMessage(): void
+    {
+        // Act
+        try {
+            Duration::fromString('');
+            $this->fail('Expected InvalidDurationException was not thrown');
+        } catch (InvalidDurationException $e) {
+            // Assert
+            $this->assertSame(['input' => ''], $e->getContext());
+            $this->assertStringContainsString('String cannot be empty', $e->getMessage());
+            $this->assertStringStartsWith('Invalid duration format:', $e->getMessage());
+            $this->assertSame(0, $e->getCode());
+        }
+    }
+
     #[DataProvider('invalidStringProvider')]
     public function testFromStringThrowsExceptionForInvalidInput(string $input): void
     {
@@ -207,6 +231,7 @@ final class DurationTest extends TestCase
             'mixed unit and naked number' => ['1h 30'],
             'too large value (overflow)' => [(string) PHP_INT_MAX],
             'overflow boundary with unit' => [intdiv(PHP_INT_MAX, 60000) + 1 . 'm'],
+            'overflow boundary (just above max safe)' => [(string) (intdiv(PHP_INT_MAX, 60000) + 1)],
         ];
     }
 }

--- a/tests/Unit/TimeEntryCollectionTest.php
+++ b/tests/Unit/TimeEntryCollectionTest.php
@@ -108,4 +108,40 @@ class TimeEntryCollectionTest extends TestCase
         $this->assertCount(1, $grouped);
         $this->assertEquals("- Work", $grouped[0]->comment);
     }
+
+    public function testConstructorAcceptsGenerator(): void
+    {
+        // Arrange
+        $date = new DateTimeImmutable('2023-01-01');
+        $generator = (function () use ($date): \Generator {
+            yield new TimeEntry('T1', Duration::fromMinutes(60), 'Dev', $date);
+            yield new TimeEntry('T2', Duration::fromMinutes(30), 'Meeting', $date);
+        })();
+
+        // Act
+        $collection = new TimeEntryCollection($generator);
+
+        // Assert
+        $this->assertCount(2, $collection->all());
+        $this->assertSame('T1', $collection->all()[0]->taskId);
+        $this->assertSame('T2', $collection->all()[1]->taskId);
+    }
+
+    public function testGroupedTrimsWhitespaceFromComments(): void
+    {
+        // Arrange
+        $date = new DateTimeImmutable('2023-01-01');
+        $entries = [
+            new TimeEntry('T1', Duration::fromMinutes(30), 'Dev', $date, '  spaced comment  '),
+        ];
+
+        $collection = new TimeEntryCollection($entries);
+
+        // Act
+        $grouped = $collection->grouped();
+
+        // Assert
+        $this->assertCount(1, $grouped);
+        $this->assertSame('- spaced comment', $grouped[0]->comment);
+    }
 }

--- a/tests/Unit/TimeEntryTest.php
+++ b/tests/Unit/TimeEntryTest.php
@@ -29,4 +29,19 @@ class TimeEntryTest extends TestCase
             comment: 'comment'
         );
     }
+
+    public function testWorkTypeCannotBeWhitespaceOnly(): void
+    {
+        // Assert
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Work type cannot be empty');
+
+        // Act
+        new TimeEntry(
+            taskId: 'TASK-1',
+            duration: Duration::fromString('1h'),
+            workType: '   ',
+            date: new DateTimeImmutable('2026-01-01'),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds a stylized ASCII banner with gradient colors to the `work:report` command.

## Key Changes
- Created `Banner` class for rendering the ASCII art.
- Added Unit tests for the `Banner` class.
- Replaced the standard Laravel Prompts `title()` with the new `Banner::render()` in `WorkReportCommand`.

Closes #66