### PR TITLE
feat: display ASCII banner on --version flag

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -5,13 +5,13 @@ declare(strict_types=1);
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Igancev\WorkReporter\Application;
 use Igancev\WorkReporter\Config\YamlConfigProvider;
 use Igancev\WorkReporter\Destination\ConcreteDestinationFactory;
 use Igancev\WorkReporter\InitCommand;
 use Igancev\WorkReporter\Source\ConcreteSourceFactory;
 use Igancev\WorkReporter\Version;
 use Igancev\WorkReporter\WorkReportCommand;
-use Symfony\Component\Console\Application;
 
 $configProvider = new YamlConfigProvider();
 $workReportCommand = new WorkReportCommand(

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igancev\WorkReporter;
+
+use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class Application extends BaseApplication
+{
+    public function doRun(InputInterface $input, OutputInterface $output): int
+    {
+        if (true === $input->hasParameterOption(['--version', '-V'], true)) {
+            Banner::render($output, $this->getVersion());
+
+            return 0;
+        }
+
+        return parent::doRun($input, $output);
+    }
+}

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Igancev\WorkReporter\Application;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(Application::class)]
+final class ApplicationTest extends TestCase
+{
+    public function testVersionOptionRendersBanner(): void
+    {
+        // Arrange
+        $app = new Application('work-reporter', '1.2.3');
+        $input = $this->createMock(InputInterface::class);
+        $input->method('hasParameterOption')
+            ->with(['--version', '-V'], true)
+            ->willReturn(true);
+        $output = new BufferedOutput();
+
+        // Act
+        $status = $app->doRun($input, $output);
+
+        // Assert
+        $this->assertSame(0, $status);
+        $content = $output->fetch();
+        $this->assertStringContainsString('v1.2.3', $content);
+        $this->assertMatchesRegularExpression('/[█▀▄]/', $content);
+    }
+
+    public function testShortVersionFlagRendersBanner(): void
+    {
+        // Arrange
+        $app = new Application('work-reporter', '2.0.0');
+        $input = $this->createMock(InputInterface::class);
+        $input->method('hasParameterOption')
+            ->with(['--version', '-V'], true)
+            ->willReturn(true);
+        $output = new BufferedOutput();
+
+        // Act
+        $status = $app->doRun($input, $output);
+
+        // Assert
+        $this->assertSame(0, $status);
+        $this->assertStringContainsString('v2.0.0', $output->fetch());
+    }
+
+    public function testWithoutVersionFlagDelegatesToParent(): void
+    {
+        // Arrange
+        $app = new Application('work-reporter', '1.0.0');
+        $app->setAutoExit(false);
+
+        $input = new ArgvInput(['console', 'list']);
+        $output = new BufferedOutput();
+
+        // Act
+        $status = $app->run($input, $output);
+
+        // Assert — no banner block characters in output, just the default list command
+        $this->assertSame(0, $status);
+        $this->assertStringNotContainsString('█', $output->fetch());
+    }
+}


### PR DESCRIPTION
Implement custom Application class to render the ASCII banner with version information when --version or -V flags are provided.

Closes #69