### PR TITLE
Fix SuperProductivity sync path and tilde expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ destination: youTrack
 # Configuration for each source type
 sources:
     superProductivity:
-        syncFilePath: ~/.config/superproductivity/__meta_
+        syncFilePath: ~/.config/superProductivity/__meta_
     plainJson:
         filePath: /path/to/time-entries.json
 

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -27,7 +27,7 @@ destination: youTrack
 # Configuration for each source type
 sources:
   superProductivity:
-    syncFilePath: ~/.config/superproductivity/__meta_
+    syncFilePath: ~/.config/superProductivity/__meta_
   plainJson:
     filePath: /path/to/time-entries.json
 

--- a/src/Source/SuperProductivity/Storage.php
+++ b/src/Source/SuperProductivity/Storage.php
@@ -21,7 +21,7 @@ readonly class Storage
      */
     public function __construct(string $syncMetaPath)
     {
-        $this->syncMetaPath = $syncMetaPath;
+        $this->syncMetaPath = str_replace("~", (string)getenv("HOME"), $syncMetaPath);
         $this->jsonData = $this->parseJson();
     }
 


### PR DESCRIPTION
## Summary
This PR fixes two issues related to SuperProductivity source configuration:
1. Updated the default sync path in `README.md` and `InitCommand` to use the correct case (`superProductivity`).
2. Added support for tilde (`~`) expansion in `Storage.php` to allow paths relative to the home directory.

Closes #81