### PR TITLE
Fix: disable GitHub logger in Infection config

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -12,7 +12,7 @@
     logs: {
         text: "var/infection.log",
         html: "var/infection.html",
-        github: true
+        github: false,
     },
     testFramework: "phpunit",
     testFrameworkOptions: "--testsuite=unit"


### PR DESCRIPTION
Disables the GitHub logger in infection.json5 to improve the readability of mutation testing results during local development.\n\n

Closes #83