### PR TITLE
Refactor configuration access with validated getters

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -24,13 +24,5 @@ readonly class Config
         if (!property_exists($this->sources, $this->source->value)) {
             throw new LogicException("Source {$this->source->value} is not supported");
         }
-
-        if ($this->destinations->{$this->destination->value} === null) {
-            throw new ConfigException("Destination {$this->destination->value} is not configured");
-        }
-
-        if ($this->sources->{$this->source->value} === null) {
-            throw new ConfigException("Source {$this->source->value} is not configured");
-        }
     }
 }

--- a/src/Config/DestinationConfig/DestinationsConfig.php
+++ b/src/Config/DestinationConfig/DestinationsConfig.php
@@ -2,10 +2,19 @@
 
 namespace Igancev\WorkReporter\Config\DestinationConfig;
 
+use Igancev\WorkReporter\Config\ConfigException;
+
 readonly class DestinationsConfig
 {
     public function __construct(
-        public ?YouTrackConfig $youTrack = null,
+        private ?YouTrackConfig $youTrack = null,
     ) {
+    }
+
+    public function getYouTrack(): YouTrackConfig
+    {
+        return $this->youTrack ?? throw new ConfigException(
+            'Destination youTrack is not configured'
+        );
     }
 }

--- a/src/Config/SourceConfig/SourcesConfig.php
+++ b/src/Config/SourceConfig/SourcesConfig.php
@@ -2,11 +2,27 @@
 
 namespace Igancev\WorkReporter\Config\SourceConfig;
 
+use Igancev\WorkReporter\Config\ConfigException;
+
 readonly class SourcesConfig
 {
     public function __construct(
-        public ?SuperProductivityConfig $superProductivity = null,
-        public ?PlainJsonConfig $plainJson = null,
+        private ?SuperProductivityConfig $superProductivity = null,
+        private ?PlainJsonConfig $plainJson = null,
     ) {
+    }
+
+    public function getPlainJson(): PlainJsonConfig
+    {
+        return $this->plainJson ?? throw new ConfigException(
+            'Source plainJson is not configured'
+        );
+    }
+
+    public function getSuperProductivity(): SuperProductivityConfig
+    {
+        return $this->superProductivity ?? throw new ConfigException(
+            'Source superProductivity is not configured'
+        );
     }
 }

--- a/src/Destination/ConcreteDestinationFactory.php
+++ b/src/Destination/ConcreteDestinationFactory.php
@@ -30,10 +30,7 @@ final readonly class ConcreteDestinationFactory implements DestinationFactory
      */
     private function buildYouTrackDestination(): YouTrackDestination
     {
-        $youtrackConfigDestinations = $this->configProvider->getConfig()->destinations->youTrack;
-        if ($youtrackConfigDestinations === null) {
-            throw new DestinationException("Definition of YouTrack destination missing in configuration");
-        }
+        $youtrackConfig = $this->configProvider->getConfig()->destinations->getYouTrack();
 
         return new YouTrackDestination(
             new HttpClientBuilder()
@@ -41,8 +38,8 @@ final readonly class ConcreteDestinationFactory implements DestinationFactory
                     new UnlimitedConnectionPool(new DefaultConnectionFactory(new DnsSocketConnector()))
                 )
                 ->build(),
-            $youtrackConfigDestinations->url,
-            $youtrackConfigDestinations->token,
+            $youtrackConfig->url,
+            $youtrackConfig->token,
         );
     }
 }

--- a/src/Source/ConcreteSourceFactory.php
+++ b/src/Source/ConcreteSourceFactory.php
@@ -28,10 +28,7 @@ final readonly class ConcreteSourceFactory implements TimeEntriesSourceFactory
      */
     private function buildPlainJsonSource(): PlainJsonTimeEntriesSource
     {
-        $config = $this->configProvider->getConfig()->sources->plainJson;
-        if ($config === null) {
-            throw new SourceException("PlainJson source configuration is missing");
-        }
+        $config = $this->configProvider->getConfig()->sources->getPlainJson();
 
         return new PlainJsonTimeEntriesSource($config->filePath);
     }
@@ -41,10 +38,7 @@ final readonly class ConcreteSourceFactory implements TimeEntriesSourceFactory
      */
     private function buildFromSuperProductivitySource(): SuperProductivitySyncSource
     {
-        $config = $this->configProvider->getConfig()->sources->superProductivity;
-        if ($config === null) {
-            throw new SourceException("SuperProductivity source configuration is missing");
-        }
+        $config = $this->configProvider->getConfig()->sources->getSuperProductivity();
 
         return new SuperProductivitySyncSource($config->syncFilePath);
     }

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Config;
 
 use Igancev\WorkReporter\Config\Config;
+use Igancev\WorkReporter\Config\ConfigException;
 use Igancev\WorkReporter\Config\DestinationConfig\DestinationsConfig;
 use Igancev\WorkReporter\Config\DestinationConfig\YouTrackConfig;
 use Igancev\WorkReporter\Config\SourceConfig\PlainJsonConfig;
@@ -46,19 +47,52 @@ final class ConfigTest extends TestCase
         $this->assertSame($destinationsConfig, $config->destinations);
     }
 
-    public function testSourcesConfigDefaults(): void
+    public function testSourcesConfigGetPlainJsonThrowsWhenNull(): void
     {
         $config = new SourcesConfig();
 
-        $this->assertNull($config->superProductivity);
-        $this->assertNull($config->plainJson);
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Source plainJson is not configured');
+
+        $config->getPlainJson();
     }
 
-    public function testDestinationsConfigDefaults(): void
+    public function testSourcesConfigGetSuperProductivityThrowsWhenNull(): void
+    {
+        $config = new SourcesConfig();
+
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Source superProductivity is not configured');
+
+        $config->getSuperProductivity();
+    }
+
+    public function testDestinationsConfigGetYouTrackThrowsWhenNull(): void
     {
         $config = new DestinationsConfig();
 
-        $this->assertNull($config->youTrack);
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Destination youTrack is not configured');
+
+        $config->getYouTrack();
+    }
+
+    public function testSourcesConfigGettersReturnValues(): void
+    {
+        $plainJson = new PlainJsonConfig('/tmp/plain.json');
+        $superProductivity = new SuperProductivityConfig('/tmp/sync');
+        $config = new SourcesConfig($superProductivity, $plainJson);
+
+        $this->assertSame($plainJson, $config->getPlainJson());
+        $this->assertSame($superProductivity, $config->getSuperProductivity());
+    }
+
+    public function testDestinationsConfigGetterReturnsValue(): void
+    {
+        $youTrack = new YouTrackConfig('http://yt.local', 'token');
+        $config = new DestinationsConfig($youTrack);
+
+        $this->assertSame($youTrack, $config->getYouTrack());
     }
 
     public function testPlainJsonConfigStoresFilePath(): void

--- a/tests/Unit/Config/YamlConfigProviderTest.php
+++ b/tests/Unit/Config/YamlConfigProviderTest.php
@@ -63,16 +63,13 @@ YAML);
 
         $this->assertSame(SourceType::SuperProductivity, $config->source);
         $this->assertSame(DestinationType::YouTrack, $config->destination);
-        $this->assertNotNull($config->sources->superProductivity);
-        $this->assertSame('/tmp/sp_sync', $config->sources->superProductivity->syncFilePath);
-        $this->assertNotNull($config->sources->plainJson);
-        $this->assertSame('/tmp/plain.json', $config->sources->plainJson->filePath);
-        $this->assertNotNull($config->destinations->youTrack);
-        $this->assertSame('http://localhost:8080', $config->destinations->youTrack->url);
-        $this->assertSame('test-token-123', $config->destinations->youTrack->token);
+        $this->assertSame('/tmp/sp_sync', $config->sources->getSuperProductivity()->syncFilePath);
+        $this->assertSame('/tmp/plain.json', $config->sources->getPlainJson()->filePath);
+        $this->assertSame('http://localhost:8080', $config->destinations->getYouTrack()->url);
+        $this->assertSame('test-token-123', $config->destinations->getYouTrack()->token);
     }
 
-    public function testThrowsExceptionWhenDestinationNotConfigured(): void
+    public function testCreatesConfigWithNullDestinationWhenNotConfigured(): void
     {
         $configPath = $this->tempDir . '/config.yaml';
         file_put_contents($configPath, <<<YAML
@@ -82,11 +79,10 @@ sources: []
 destinations: []
 YAML);
 
-        $this->expectException(ConfigException::class);
-        $this->expectExceptionMessage('Destination youTrack is not configured');
-
         $provider = new YamlConfigProvider($configPath);
-        $provider->getConfig();
+        $config = $provider->getConfig();
+
+        $this->assertSame(DestinationType::YouTrack, $config->destination);
     }
 
     public function testCachesConfigOnSubsequentCalls(): void
@@ -401,9 +397,9 @@ YAML);
         $provider = new YamlConfigProvider($configPath);
         $config = $provider->getConfig();
 
-        $this->assertNotNull($config->sources->superProductivity);
-        $this->assertNull($config->sources->plainJson);
-        $this->assertSame('/tmp/sync', $config->sources->superProductivity->syncFilePath);
+        $this->assertSame('/tmp/sync', $config->sources->getSuperProductivity()->syncFilePath);
+        $this->expectException(ConfigException::class);
+        $config->sources->getPlainJson();
     }
 
     public function testParsesConfigWithOnlyPlainJsonSource(): void
@@ -424,8 +420,8 @@ YAML);
         $provider = new YamlConfigProvider($configPath);
         $config = $provider->getConfig();
 
-        $this->assertNull($config->sources->superProductivity);
-        $this->assertNotNull($config->sources->plainJson);
-        $this->assertSame('/tmp/data.json', $config->sources->plainJson->filePath);
+        $this->assertSame('/tmp/data.json', $config->sources->getPlainJson()->filePath);
+        $this->expectException(ConfigException::class);
+        $config->sources->getSuperProductivity();
     }
 }


### PR DESCRIPTION
## Summary
- Encapsulated source and destination configuration properties.
- Added getters that throw `ConfigException` when a required configuration section is missing.
- Simplified factories by removing manual null checks.
- Updated tests to cover new behavior and ensured PSR-12 compliance.

Closes #85