### PR TITLE
fix: resolve home directory via cross-platform helper (partial #68)

### DIFF
--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Igancev\WorkReporter\Cli;
 
+use Igancev\WorkReporter\Platform\HomeDirectory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -55,7 +56,7 @@ YAML;
     {
         $io = new SymfonyStyle($input, $output);
 
-        $home = (string) getenv('HOME');
+        $home = HomeDirectory::resolve();
         $configDir = str_replace('~', $home, self::DEFAULT_CONFIG_DIR);
         $configPath = str_replace('~', $home, self::DEFAULT_CONFIG_PATH);
 

--- a/src/Config/YamlConfigProvider.php
+++ b/src/Config/YamlConfigProvider.php
@@ -8,6 +8,7 @@ use Igancev\WorkReporter\Config\SourceConfig\PlainJsonConfig;
 use Igancev\WorkReporter\Config\SourceConfig\SourcesConfig;
 use Igancev\WorkReporter\Config\SourceConfig\SuperProductivityConfig;
 use Igancev\WorkReporter\Destination\DestinationType;
+use Igancev\WorkReporter\Platform\HomeDirectory;
 use Igancev\WorkReporter\Source\SourceType;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -28,7 +29,7 @@ class YamlConfigProvider implements ConfigProvider
             return $this->config;
         }
 
-        $path = str_replace("~", (string)getenv("HOME"), $this->configPath);
+        $path = str_replace("~", HomeDirectory::resolve(), $this->configPath);
 
         if (!file_exists($path)) {
             throw new ConfigException(sprintf(

--- a/src/Platform/HomeDirectory.php
+++ b/src/Platform/HomeDirectory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igancev\WorkReporter\Platform;
+
+/**
+ * Cross-platform helper to resolve the current user's home directory.
+ *
+ * `HOME` is the POSIX convention used by Linux and macOS. On Windows the
+ * canonical equivalent is `USERPROFILE`, with `HOMEDRIVE` + `HOMEPATH` as a
+ * last-resort fallback when shells / containers strip `USERPROFILE`. Reading
+ * `HOME` directly on Windows usually returns an empty string and silently
+ * resolves `~`-prefixed config paths to the filesystem root.
+ */
+final class HomeDirectory
+{
+    public static function resolve(): string
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $userProfile = (string) getenv('USERPROFILE');
+            if ($userProfile !== '') {
+                return $userProfile;
+            }
+
+            $drive = (string) getenv('HOMEDRIVE');
+            $path = (string) getenv('HOMEPATH');
+            if ($drive !== '' || $path !== '') {
+                return $drive . $path;
+            }
+
+            return '';
+        }
+
+        return (string) getenv('HOME');
+    }
+}

--- a/tests/Unit/Platform/HomeDirectoryTest.php
+++ b/tests/Unit/Platform/HomeDirectoryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Platform;
+
+use Igancev\WorkReporter\Platform\HomeDirectory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HomeDirectory::class)]
+final class HomeDirectoryTest extends TestCase
+{
+    private string|false $originalHome;
+    private string|false $originalUserProfile;
+    private string|false $originalHomeDrive;
+    private string|false $originalHomePath;
+
+    protected function setUp(): void
+    {
+        // Arrange
+        $this->originalHome = getenv('HOME');
+        $this->originalUserProfile = getenv('USERPROFILE');
+        $this->originalHomeDrive = getenv('HOMEDRIVE');
+        $this->originalHomePath = getenv('HOMEPATH');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnv('HOME', $this->originalHome);
+        $this->restoreEnv('USERPROFILE', $this->originalUserProfile);
+        $this->restoreEnv('HOMEDRIVE', $this->originalHomeDrive);
+        $this->restoreEnv('HOMEPATH', $this->originalHomePath);
+    }
+
+    public function testResolveReturnsHomeOnPosix(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            self::markTestSkipped('POSIX-only path; Windows uses USERPROFILE.');
+        }
+
+        // Arrange
+        putenv('HOME=/home/posix-user');
+
+        // Act
+        $home = HomeDirectory::resolve();
+
+        // Assert
+        self::assertSame('/home/posix-user', $home);
+    }
+
+    public function testResolvePrefersUserProfileOnWindows(): void
+    {
+        if (PHP_OS_FAMILY !== 'Windows') {
+            self::markTestSkipped('Windows-only path; POSIX uses HOME.');
+        }
+
+        // Arrange
+        putenv('USERPROFILE=C:\\Users\\winuser');
+        putenv('HOMEDRIVE=Z:');
+        putenv('HOMEPATH=\\Z-path');
+
+        // Act
+        $home = HomeDirectory::resolve();
+
+        // Assert
+        self::assertSame('C:\\Users\\winuser', $home);
+    }
+
+    public function testResolveFallsBackToHomeDrivePathOnWindowsWhenUserProfileEmpty(): void
+    {
+        if (PHP_OS_FAMILY !== 'Windows') {
+            self::markTestSkipped('Windows-only fallback path.');
+        }
+
+        // Arrange
+        putenv('USERPROFILE');
+        putenv('HOMEDRIVE=C:');
+        putenv('HOMEPATH=\\Users\\fallback');
+
+        // Act
+        $home = HomeDirectory::resolve();
+
+        // Assert
+        self::assertSame('C:\\Users\\fallback', $home);
+    }
+
+    public function testResolveReturnsEmptyStringWhenEnvUnset(): void
+    {
+        // Arrange
+        if (PHP_OS_FAMILY === 'Windows') {
+            putenv('USERPROFILE');
+            putenv('HOMEDRIVE');
+            putenv('HOMEPATH');
+        } else {
+            putenv('HOME');
+        }
+
+        // Act
+        $home = HomeDirectory::resolve();
+
+        // Assert
+        self::assertSame('', $home);
+    }
+
+    private function restoreEnv(string $name, string|false $original): void
+    {
+        if ($original === false) {
+            putenv($name);
+            return;
+        }
+        putenv($name . '=' . $original);
+    }
+}


### PR DESCRIPTION
## Summary

`InitCommand` and `YamlConfigProvider` read `getenv('HOME')` directly to expand the leading `~` in the default config path. On Windows that env var is usually unset (the OS uses `USERPROFILE`, with `HOMEDRIVE` + `HOMEPATH` as a documented fallback for shells / containers that strip `USERPROFILE`), so `~/.config/work-reporter/...` quietly resolved to `/.config/work-reporter/...` at the filesystem root and `init` + `work:report` silently misbehaved.

## What changed

- New `Igancev\WorkReporter\Platform\HomeDirectory::resolve()` helper that returns the canonical home directory per platform: `HOME` on POSIX, `USERPROFILE` on Windows with the documented `HOMEDRIVE` + `HOMEPATH` fallback. Returns an empty string when nothing is set so callers see the same shape as the prior `(string)getenv(...)` cast (no behavior change in error reporting paths).
- `src/Cli/InitCommand.php`: swap the bare `getenv('HOME')` for `HomeDirectory::resolve()`.
- `src/Config/YamlConfigProvider.php`: same swap.
- `tests/Unit/Platform/HomeDirectoryTest.php`: per-platform branches: POSIX returns `HOME`, Windows prefers `USERPROFILE` even when `HOMEDRIVE`+`HOMEPATH` are set, Windows falls back to `HOMEDRIVE`+`HOMEPATH` when `USERPROFILE` is empty, and all-unset returns `""`. Each test skips on the other OS family; cross-OS assertions exercise on a future Windows CI lane.

## Scope

This is a partial fix for #68 — only the **env-var handling** item on the checklist. The remaining items (Windows binary build workflow, README install section, Windows binary smoke test) are intentionally left for follow-up PRs so each item stays atomic per CLAUDE.md / CONTRIBUTING.md guidance. Happy to take any of those in a follow-up if you want.

## Verification

Local (macOS / PHP 8.5):

```bash
vendor/bin/phpunit tests/Unit/Platform/HomeDirectoryTest.php
# 4 tests, 2 assertions, 2 skipped (Windows-only branches)

vendor/bin/phpunit tests/Unit/InitCommandTest.php tests/Unit/Config/YamlConfigProviderTest.php
# 27 tests, 63 assertions, no regressions

make cs            # 72/72 files clean
make stat-analyze  # phpstan 0 errors
```

Closes part of #68 (env-var handling only).
